### PR TITLE
Omit no "virtual"-keyword for sealed types

### DIFF
--- a/Dolly.Tests/ModelTests.cs
+++ b/Dolly.Tests/ModelTests.cs
@@ -12,6 +12,7 @@ public class ModelTests
     [Arguments(ModelFlags.Struct, "partial struct")]
     [Arguments(ModelFlags.Struct | ModelFlags.ClonableBase, "partial struct")] // Cannot occur
     [Arguments(ModelFlags.ClonableBase, "partial class")]
+    [Arguments(ModelFlags.Record | ModelFlags.IsSealed, "partial record")]
     public async Task Modifiers(ModelFlags flags, string expected)
     {
         var model = new Model("test", "test", flags, [], []);
@@ -24,6 +25,7 @@ public class ModelTests
     [Arguments(ModelFlags.Struct, "")]
     [Arguments(ModelFlags.Struct | ModelFlags.ClonableBase, "override")] // Cannot occur
     [Arguments(ModelFlags.ClonableBase, "override")]
+    [Arguments(ModelFlags.IsSealed, "")]
     public async Task MethodModifiers(ModelFlags flags, string expected)
     {
         var model = new Model("test", "test", flags, [], []);

--- a/Dolly/SourceTextConverter.cs
+++ b/Dolly/SourceTextConverter.cs
@@ -1,0 +1,54 @@
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dolly
+{
+    /// <summary>
+    /// Provides functionality to convert a <see cref="Model"/> into a <see cref="SourceText"/> representation.
+    /// </summary>
+    public class SourceTextConverter
+    {
+        /// <summary>
+        /// Converts the given <see cref="Model"/> into a <see cref="SourceText"/> object.
+        /// </summary>
+        /// <param name="model">The model to convert into source text.</param>
+        /// <returns>A <see cref="SourceText"/> object representing the generated source code for the model.</returns>
+        public static SourceText ToSourceText(Model model)
+        {
+            return SourceText.From($$"""
+                    using Dolly;
+                    using System.Linq;
+                    namespace {{model.Namespace}};
+                    {{model.GetModifiers()}} {{model.Name}} : IClonable<{{model.Name}}>
+                    {
+                        {{(!model.HasClonableBaseClass ? "object ICloneable.Clone() => this.DeepClone();" : "")}}
+                        public {{model.GetMethodModifiers()}}{{model.Name}} DeepClone() =>
+                            new ({{string.Join(", ", model.Constructor.Select(m => m.ToString(true)))}})
+                            {
+                    {{GenerateCloneMembers(model, true)}}
+                            };
+
+                        public {{model.GetMethodModifiers()}}{{model.Name}} ShallowClone() =>
+                            new ({{string.Join(", ", model.Constructor.Select(m => m.ToString(false)))}})
+                            {
+                    {{GenerateCloneMembers(model, false)}}
+                            };
+                    }
+                    """.Replace("\r\n", "\n"), Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Generates the member initialization code for cloning operations.
+        /// </summary>
+        /// <param name="model">The model containing the members to clone.</param>
+        /// <param name="deepClone">Indicates whether to generate deep clone or shallow clone member initializations.</param>
+        /// <returns>A string containing the member initialization code.</returns>
+        private static string GenerateCloneMembers(Model model, bool deepClone) =>
+            string.Join(",\n",
+                model.Members
+                .Select(m => $"{new string(' ', 12)}{m.Name} = {m.ToString(deepClone)}")
+            );
+    }
+}


### PR DESCRIPTION
Fixes #2

Note: 
- I prefer simple input/output comparisons over model comparisons within tests (I could change this, but I don’t see a significant gain; on the contrary, comparing/asserting the model increases the complexity in my opinion).
- A struct is always sealed.


(I will probably also fix #1 after this one)

