### PR TITLE
Add the real FastCloner to the benchmark and correct FastDeepCloner's name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,4 @@ FodyWeavers.xsd
 
 # Generated files
 /Dolly/Generated/*
+/.idea

--- a/Dolly.Benchmarks/CloneBenchmarks.cs
+++ b/Dolly.Benchmarks/CloneBenchmarks.cs
@@ -6,6 +6,7 @@ using NClone;
 namespace Dolly.Benchmarks;
 
 [MemoryDiagnoser]
+[Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
 public class CloneBenchmarks
 {
     private readonly ComplexClass _complexClass;
@@ -89,8 +90,8 @@ public class CloneBenchmarks
         DeepClonerExtensions.DeepClone(_complexClass);
     }
 
-    [Benchmark(Description = "FastCloner")]
-    public void TestFastCloner()
+    [Benchmark(Description = "FastDeepCloner")]
+    public void TestFastDeepCloner()
     {
         var clone = FastDeepCloner.DeepCloner.Clone(_complexClass);
     }
@@ -105,5 +106,11 @@ public class CloneBenchmarks
     public void TestAnyClone()
     {
         var clone = AnyClone.CloneExtensions.Clone(_complexClass);
+    }
+    
+    [Benchmark(Description = "FastCloner")]
+    public void TestFastCloner()
+    {
+        var clone = _complexClass.FastDeepClone();
     }
 }

--- a/Dolly.Benchmarks/Dolly.Benchmarks.csproj
+++ b/Dolly.Benchmarks/Dolly.Benchmarks.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="CloneExtensions" Version="1.4.2" />
     <PackageReference Include="DeepCloner" Version="0.10.4" />
+    <PackageReference Include="FastCloner.SourceGenerator" Version="1.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FastCloner.SourceGenerator.Shared" Version="1.0.0" />
     <PackageReference Include="FastDeepCloner" Version="1.3.6" />
     <PackageReference Include="NClone" Version="1.2.0" />
   </ItemGroup>

--- a/Dolly.Benchmarks/SimpleClass.cs
+++ b/Dolly.Benchmarks/SimpleClass.cs
@@ -1,3 +1,5 @@
+using FastCloner.SourceGenerator.Shared;
+
 namespace Dolly.Benchmarks;
 
 public class SimpleClassBase
@@ -6,6 +8,7 @@ public class SimpleClassBase
 }
 
 [Clonable]
+[FastClonerClonable]
 public partial class SimpleClass : SimpleClassBase
 {
     public int Int { get; set; }
@@ -18,6 +21,7 @@ public partial class SimpleClass : SimpleClassBase
 }
 
 [Clonable]
+[FastClonerClonable]
 public partial class ComplexClass
 {
     public SimpleClass SimpleClass { get; set; }


### PR DESCRIPTION
Hi @AnderssonPeter!

Not sure if you remember but we were in contact (from Reddit), you've talked about Dolly there. It seems like a great deal of work has been done since then! 

I've looked at the repository today (recommended by GitHub) and noticed there might be a small mistake in the readme - the benchmark mentions `FastCloner`, which is actually a library I [maintain](https://github.com/lofcz/FastCloner), but I believe you meant `FastDeepCloner`.

To clarify the difference, I've added the actual FastCloner to the benchmark. Here are the results:

<img width="1280" height="428" alt="Benchmark comparison" src="https://github.com/user-attachments/assets/2a043f2e-ddc3-4546-b12c-b84cdf6825f0" />

Feel free to update the readme as you see fit - happy to help if needed!

Best of luck with the project!
